### PR TITLE
Production info fixes

### DIFF
--- a/anacreon.py
+++ b/anacreon.py
@@ -772,9 +772,9 @@ class Anacreon:
 
                         if actual is None:
 
-                            entry['exported'] += optimal
+                            entry['imported'] += optimal
                         else:
-                            entry['exported'] += actual
+                            entry['imported'] += actual
 
                         entry['importedOptimal'] += optimal
 

--- a/anacreon.py
+++ b/anacreon.py
@@ -741,9 +741,9 @@ class Anacreon:
                         for partnerTradeRoute in partnerObj['tradeRoutes']:
                             if partnerTradeRoute['partnerObjID'] == world_id:
                                 if "exports" in partnerTradeRoute.keys():
-                                    exports = partnerTradeRoute['exports']
+                                    imports = partnerTradeRoute['exports']
                                 if "imports" in partnerTradeRoute.keys():
-                                    imports = partnerTradeRoute['imports']
+                                    exports = partnerTradeRoute['imports']
                 else:
                     if "exports" in tradeRoute.keys():
                         exports = tradeRoute['exports']


### PR DESCRIPTION
Easy way to check production info values:

```
world = my_worlds[0]

print('world: ', world['name'])
print('designation: ', api.scenario_info[world['designation']]['nameDesc'])

world['production_info'] = api.generate_production_info(world['id'])

 # replace resource codes with readable names
new_info = {}
for key, val in world['production_info'].items():
    res = api.scenario_info[key]['nameDesc']
    new_info[res] = val
world['production_info'] = new_info

print('production info:')
print(json.dumps(world['production_info'], indent=4))
```

By trying this code on different planets one can notice that some import/export values were wrong.